### PR TITLE
[ModelZoo] add models base image

### DIFF
--- a/base_image/Dockerfile
+++ b/base_image/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.7
+
+# install PAI python support
+RUN pip install pypai
+
+# install go needed by installing ElasticDL
+ENV GOPATH /root/go
+ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH
+RUN curl --silent https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+
+# install ElasticDL to manage ElasticDL jobs
+RUN git clone https://github.com/sql-machine-learning/elasticdl.git && \
+cd elasticdl && \
+git checkout eb93e2a48e6fe8f077c4937d8c0c5987faa9cf56 && \
+pip install -r elasticdl/requirements.txt && \
+python setup.py install

--- a/sqlflow_models/Dockerfile
+++ b/sqlflow_models/Dockerfile
@@ -1,0 +1,4 @@
+FROM sqlflow/modelzoo_base
+
+RUN pip install tensorflow==2.0.0b1 scikit-learn==0.20.0 numpy==1.16.2 pandas==0.25.1
+ADD *.py /sqlflow_models/


### PR DESCRIPTION
1. build the base image: `cd base_image && docker build -t sqlflow/modelzoo_base .`
1. build sqlflow_models image: `cd sqlflow_models && docker build -t sqlflow/sqlflow_models .`
1. then the models can be imported by: docker run --rm -e PYTHONPATH=/ sqlflow_models python -c "from sqlflow_models import DNNClassifier"

TODO: Add tests using these docker images to ensure both SQLFlow and ElasticDL can use these model: https://github.com/sql-machine-learning/models/pull/25#discussion_r344876585