### PR TITLE
Change value of parameter `verbose` from default 1 to 2 

### DIFF
--- a/sqlflow_models/deep_embedding_cluster.py
+++ b/sqlflow_models/deep_embedding_cluster.py
@@ -165,7 +165,8 @@ class DeepEmbeddingClusterModel(keras.Model):
             ReduceLROnPlateau(monitor='loss', factor=0.1, patience=2)
         ]
         print('{} Training auto-encoder.'.format(datetime.now()))
-        self._autoencoder.fit_generator(generator=y, epochs=self._pretrain_epochs, callbacks=callbacks)
+        self._autoencoder.fit_generator(generator=y, epochs=self._pretrain_epochs, callbacks=callbacks,
+                                        verbose=2)
         # encoded_input
         # type : numpy.ndarray shape : (num_of_all_records,num_of_cluster) (70000,10) if mnist
         print('{} Calculating encoded_input.'.format(datetime.now()))


### PR DESCRIPTION
Change value of parameter `verbose` from default 1 to 2 to avoid unnecessary trainning details.