### PR TITLE
Disable zip to ensure copying source from dist_package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,4 +133,5 @@ setup(
     cmdclass={
         'upload': UploadCommand,
     },
+    zip_safe=False,
 )


### PR DESCRIPTION
This is to eliminate the following error:
```
ERROR: runSQLProgram error: failed /bin/cp -r /usr/local/lib/python3.6/dist-packages/sqlflow_models-0.0.1-py3.6.egg/sqlflow_models ., exit status 1
```