### PR TITLE
Make sklearn version larger to support sklearn2pmml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'tensorflow==2.0.1', 'scikit-learn>=0.23.0', 'numpy==1.16.2', 'pandas==0.25.1', 'adanet==0.8.0', "tensorflow-datasets==3.0.0"
+    'tensorflow==2.0.1', 'scikit-learn==0.21.0', 'numpy==1.16.2', 'pandas==0.25.1', 'adanet==0.8.0', "tensorflow-datasets==3.0.0"
 ]
 SETUP_REQUIRED = [
     'pytest-runner'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'tensorflow==2.0.1', 'scikit-learn==0.20.0', 'numpy==1.16.2', 'pandas==0.25.1', 'adanet==0.8.0', "tensorflow-datasets==3.0.0"
+    'tensorflow==2.0.1', 'scikit-learn>=0.23.0', 'numpy==1.16.2', 'pandas==0.25.1', 'adanet==0.8.0', "tensorflow-datasets==3.0.0"
 ]
 SETUP_REQUIRED = [
     'pytest-runner'

--- a/sqlflow_models/Dockerfile
+++ b/sqlflow_models/Dockerfile
@@ -1,4 +1,4 @@
 FROM sqlflow/modelzoo_base
 
-RUN pip install tensorflow==2.0.0 scikit-learn>=0.23.0 numpy==1.16.2 pandas==0.25.1
+RUN pip install tensorflow==2.0.0 scikit-learn==0.21.0 numpy==1.16.2 pandas==0.25.1
 ADD *.py /sqlflow_models/

--- a/sqlflow_models/Dockerfile
+++ b/sqlflow_models/Dockerfile
@@ -1,4 +1,4 @@
 FROM sqlflow/modelzoo_base
 
-RUN pip install tensorflow==2.0.0 scikit-learn==0.20.0 numpy==1.16.2 pandas==0.25.1
+RUN pip install tensorflow==2.0.0 scikit-learn>=0.23.0 numpy==1.16.2 pandas==0.25.1
 ADD *.py /sqlflow_models/


### PR DESCRIPTION
Make sklearn version from 0.20.0 to 0.21.0, because sklearn2pmml (a tool to convert sklearn pipeline to pmml) cannot work with sklearn 0.20.0 well. 

TODO: make the requirement be `scikit-learn>=xxx` instead of `scikit-learn==xxx`. But since 0.23.0, sklearn's API is quite different. For example, `sklearn.utils.linear_assignment_` does not exist in 0.23.0, but we used this API [here](https://github.com/sql-machine-learning/models/blob/f5236bc83cfc8e2c181fe42ffadf764376c8d591/tests/test_deep_embedding_cluster.py#L9) .