### PR TITLE
Add GCN

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ REQUIRED = [
     'adanet==0.8.0',
     "tensorflow-datasets==3.0.0",
     "statsmodels==0.11.1",
+    "scipy==1.4.1",
 ]
 
 SETUP_REQUIRED = [

--- a/sqlflow_models/__init__.py
+++ b/sqlflow_models/__init__.py
@@ -8,7 +8,7 @@ from .dnnclassifier_functional_api_example import dnnclassifier_functional_model
 from .rnn_based_time_series import RNNBasedTimeSeriesModel
 from .auto_estimator import AutoClassifier, AutoRegressor
 from .native_keras import RawDNNClassifier
-from .custom_model_example import CustomClassifier
+from .gcn import GCN
 try:
     # NOTE: statsmodels have version conflict on PAI
     from .arima_with_stl_decomposition import ARIMAWithSTLDecomposition

--- a/sqlflow_models/__init__.py
+++ b/sqlflow_models/__init__.py
@@ -8,6 +8,7 @@ from .dnnclassifier_functional_api_example import dnnclassifier_functional_model
 from .rnn_based_time_series import RNNBasedTimeSeriesModel
 from .auto_estimator import AutoClassifier, AutoRegressor
 from .native_keras import RawDNNClassifier
+from .custom_model_example import CustomClassifier
 from .gcn import GCN
 try:
     # NOTE: statsmodels have version conflict on PAI

--- a/sqlflow_models/gcn.py
+++ b/sqlflow_models/gcn.py
@@ -1,0 +1,354 @@
+# Based on the code from: https://github.com/tkipf/keras-gcn
+import tensorflow as tf
+from tensorflow.keras import activations, initializers, constraints
+from tensorflow.keras import regularizers
+import tensorflow.keras.backend as K
+import scipy.sparse as sp
+import numpy as np
+import pickle, copy
+
+
+# Graph Convolutional Neural Networks
+class GCN(tf.keras.Model):
+    def __init__(self, nhid, nclass, epochs, train_ratio, eval_ratio, early_stopping=True, dropout=0.5, nlayer=2, feature_columns=None):
+        """GCN
+        :param nhid: Number of hidden units for GCN.
+            type nhid: int.
+        :param nclass: Number of classes in total which will be the output dimension.
+            type nclass: int.
+        :param epochs: Number of epochs for the model to be trained.
+            type epochs: int.
+        :param train_ratio: Percentage of data points to be used for training.
+            type train_ratio: float.
+        :param eval_ratio: Percentage of data points to be used for evaluating.
+            type eval_ratio: float.
+        :param early_stopping: Whether to use early stopping trick during the training phase.
+            type early_stopping: bool.
+        :param dropout: The rate for dropout.
+            type dropout: float.
+        :param nlayer: Number of GCNLayer to be used in the model.
+            type nlayer: int.
+        :param feature_columns: a list of tf.feature_column. (Not used in this model)
+            type feature_columns: list.
+        """
+        super(GCN, self).__init__()
+
+        self.gc_layers = list()
+        self.gc_layers.append(GCNLayer(nhid, kernel_regularizer=tf.keras.regularizers.l2(5e-4)))
+        if nlayer > 2:
+            for i in range(nlayer-2):
+                self.gc_layers.append(GCNLayer(nhid, kernel_regularizer=tf.keras.regularizers.l2(5e-4)))
+        self.gc_layers.append(GCNLayer(nclass))
+        self.keep_prob = 1 - dropout
+        self.dropout = tf.keras.layers.Dropout(dropout)
+        self.nshape = None
+        self.train_ratio = train_ratio
+        self.eval_ratio = eval_ratio
+        self.nlayer = nlayer
+        self.epochs = epochs
+        self.early_stopping = early_stopping
+
+    def call(self, data):
+        x, adj = data
+        assert self.nshape is not None, "Should calculate the shape of input by preprocessing the data with model.preprocess(data)"
+        x = self.dropout(x)
+        for i in range(self.nlayer-1):
+            x = tf.keras.activations.relu(self.gc_layers[i](x, adj))
+            x = self.dropout(x)
+        x = self.gc_layers[-1](x, adj)
+
+        return tf.keras.activations.softmax(x)
+
+    @staticmethod
+    def encode_onehot(labels):
+        classes = set(labels)
+        classes_dict = {c: np.identity(len(classes))[i, :] for i, c in enumerate(classes)}
+        labels_onehot = np.array(list(map(classes_dict.get, labels)), dtype=np.int32)
+        return labels_onehot
+
+    @staticmethod
+    def normalize_adj(adjacency, symmetric=True):
+        """
+        Function to normalize the adjacency matrix (get the laplacian matrix).
+        :param adjacency: Adjacency matrix of the dataset.
+            type adjacency: Scipy COO_Matrix.
+        :param symmetric: Boolean variable to determine whether to use symmetric laplacian.
+            type symmetric: bool.
+        """
+        adjacency += sp.eye(adjacency.shape[0])
+        if symmetric:
+            """L=D^-0.5 * (A+I) * D^-0.5"""
+            d = sp.diags(np.power(np.array(adjacency.sum(1)), -0.5).flatten(), 0)
+            a_norm = adjacency.dot(d).transpose().dot(d).tocoo()
+        else:
+            """L=D^-1 * (A+I)"""
+            d = sp.diags(np.power(np.array(adjacency.sum(1)), -1).flatten(), 0)
+            a_norm = d.dot(adjacency).tocoo()
+
+        return a_norm
+
+    @staticmethod
+    def normalize_feature(features):
+        """Function to row-normalize the features input."""
+        rowsum = np.array(features.sum(1))
+        r_inv = np.power(rowsum, -1).flatten()
+        r_inv[np.isinf(r_inv)] = 0.
+        r_mat_inv = sp.diags(r_inv)
+        features = r_mat_inv.dot(features)
+        return features
+
+    @staticmethod
+    def sparse_dropout(x, keep_prob, noise_shape):
+        """Dropout for sparse tensors in Tensorflow."""
+        random_tensor = keep_prob
+        random_tensor += tf.random.uniform(noise_shape)
+        dropout_mask = tf.cast(tf.floor(random_tensor), dtype=tf.bool)
+        pre_out = tf.sparse.retain(x, dropout_mask)
+        return pre_out * (1./keep_prob)
+
+    def preprocess(self, ids, features, labels, edges):
+        """Function to preprocess the node features and adjacency matrix."""
+        if len(features.shape) > 2:
+            features = np.squeeze(features)
+        if len(edges.shape) > 2:
+            edges = np.squeeze(edges)
+        # sort the data in the correct order
+        idx = np.argsort(np.array(ids))
+        features = features[idx]
+        labels = labels[idx]
+        # preprocess
+        features = GCN.normalize_feature(features)
+        labels = GCN.encode_onehot(labels)
+        adjacency = sp.coo_matrix((np.ones(len(edges)),
+                    (edges[:, 0], edges[:, 1])),
+                    shape=(features.shape[0], features.shape[0]), dtype="float32")
+
+        adjacency = adjacency + adjacency.T.multiply(adjacency.T > adjacency) - adjacency.multiply(adjacency.T > adjacency)
+        adjacency = GCN.normalize_adj(adjacency, symmetric=True)
+
+        nf_shape = features.data.shape
+        na_shape = adjacency.data.shape
+        adjacency = tf.SparseTensor(
+                        indices=np.array(list(zip(adjacency.row, adjacency.col)), dtype=np.int64),
+                        values=tf.cast(adjacency.data, tf.float32),
+                        dense_shape=adjacency.shape)
+        adjacency = tf.sparse.reorder(adjacency)
+        
+        total_num = features.shape[0]
+        train_num = round(total_num*self.train_ratio)
+        eval_num = round(total_num*self.eval_ratio)
+        train_index = np.arange(train_num)
+        val_index = np.arange(train_num, train_num+eval_num)
+        test_index = np.arange(train_num+eval_num, total_num)
+
+        self.train_mask = np.zeros(total_num, dtype = np.bool)
+        self.val_mask = np.zeros(total_num, dtype = np.bool)
+        self.test_mask = np.zeros(total_num, dtype = np.bool)
+        self.train_mask[train_index] = True
+        self.val_mask[val_index] = True
+        self.test_mask[test_index] = True
+
+        print('Dataset has {} nodes, {} edges, {} features.'.format(features.shape[0], edges.shape[0], features.shape[1]))
+
+        return features, labels, adjacency, nf_shape, na_shape
+    
+    def loss_func(self, model, x, y, train_mask, training=True):
+        '''Customed loss function for the model.'''
+
+        y_ = model(x, training=training)
+
+        test_mask_logits = tf.gather_nd(y_, tf.where(train_mask))
+        masked_labels = tf.gather_nd(y, tf.where(train_mask))
+
+        return loss(labels=masked_labels, output=test_mask_logits)
+
+    def grad(self, model, inputs, targets, train_mask):
+        '''Calculate the gradients of the parameters.'''
+        with tf.GradientTape() as tape:
+            loss_value = self.loss_func(model, inputs, targets, train_mask)
+        
+        return loss_value, tape.gradient(loss_value, model.trainable_variables)
+    
+    def test(self, mask):
+        '''Test the results on the model. Return accuracy'''
+        logits = self.predict(x=[self.features, self.adjacency], batch_size=int(self.features.shape[0]))
+
+        test_mask_logits = tf.gather_nd(logits, tf.where(mask))
+        masked_labels = tf.gather_nd(self.labels, tf.where(mask))
+
+        ll = tf.equal(tf.argmax(masked_labels, -1), tf.argmax(test_mask_logits, -1))
+        accuarcy = tf.reduce_mean(tf.cast(ll, dtype=tf.float32))
+
+        return accuarcy
+
+    def sqlflow_train_loop(self, x):
+        """Customized training function."""
+        # load data
+        ids, ids_check, features, labels, edges, edge_check = list(), dict(), list(), list(), list(), dict()
+        from_node = 0
+        for inputs, label in x:
+            id = inputs['id'].numpy().astype(np.int32)
+            feature = inputs['features'].numpy().astype(np.float32)
+            from_node = inputs['from_node_id'].numpy().astype(np.int32)
+            to_node = inputs['to_node_id'].numpy().astype(np.int32)
+            if int(id) not in ids_check:
+                ids.append(int(id))
+                features.append(feature)
+                labels.append(label.numpy()[0])
+                ids_check[int(id)] = 0
+            if tuple([int(from_node), int(to_node)]) not in edge_check:
+                edge_check[tuple([int(from_node), int(to_node)])] = 0
+                edges.append([from_node, to_node])
+        features = np.stack(features)
+        labels = np.stack(labels)
+        edges = np.stack(edges)
+
+        self.features, self.labels, self.adjacency, self.nshape, na_shape = self.preprocess(ids, features, labels, edges)
+        # training the model
+        wait = 0
+        best_acc = -9999999
+        PATIENCE = 10
+        for epoch in range(self.epochs):
+            # calculate the gradients and take the step
+            loss_value, grads = self.grad(self, [self.features, self.adjacency], self.labels, self.train_mask)
+            optimizer().apply_gradients(zip(grads, self.trainable_variables))
+            # Test on train and evaluate dataset
+            train_acc = self.test(self.train_mask)
+            val_acc = self.test(self.val_mask)
+            print("Epoch {} loss={:6f} accuracy={:6f} val_acc={:6f}".format(epoch, loss_value, train_acc, val_acc))
+            # early stopping
+            if epoch > 50 and self.early_stopping:
+                if float(val_acc.numpy()) > best_acc:
+                    best_acc = float(val_acc.numpy())
+                    wait = 0
+                else:
+                    if wait >= PATIENCE:
+                        print('Epoch {}: early stopping'.format(epoch))
+                        break
+                    wait += 1
+        # evaluate the model
+        result = self.evaluate(x=[self.features, self.adjacency], y=self.labels, 
+                                    batch_size=int(self.features.shape[0]), sample_weight=self.val_mask, verbose=0)
+        # get all the results
+        predicted = self.predict(x=[self.features, self.adjacency], batch_size=int(self.features.shape[0]))
+        # store the results in a pickled file
+        with open('./results.p', 'wb') as f:
+            results = dict()
+            for i in range(len(ids)):
+                results[ids[i]] = predicted[i]
+            results['evaluation'] = result
+            pickle.dump(results, f)
+
+    def sqlflow_evaluate_loop(self, x, metric_names):
+        """Customed evaluation, can only support calculating the accuracy."""
+        with open('./results.p', 'rb') as f:
+            results = pickle.load(f)
+            eval_result = results['evaluation']
+        return eval_result
+
+    def sqlflow_predict_one(self, sample):
+        """Customed prediction, sample must be the node id."""
+        with open('./results.p', 'rb') as f:
+            results = pickle.load(f)
+            prediction = results[sample]
+        
+        return [prediction]
+
+def optimizer():
+    """Default optimizer name. Used in model.compile."""
+    return tf.keras.optimizers.Adam(lr=0.01)
+
+def loss(labels, output):
+    """Default loss function for classification task."""
+    criterion = tf.keras.losses.CategoricalCrossentropy(from_logits=False)
+    return criterion(y_true=labels, y_pred=output)
+
+# Graph Convolutional Layer
+class GCNLayer(tf.keras.layers.Layer):
+ 
+    def __init__(self, units, use_bias=True, sparse_input=False,
+                 kernel_initializer='glorot_uniform',
+                 bias_initializer='zeros',
+                 kernel_regularizer=None,
+                 bias_regularizer=None,
+                 kernel_constraint=None,
+                 bias_constraint=None,
+                 **kwargs):
+        """GCNLayer
+        Graph Convolutional Networks Layer from paper: https://arxiv.org/pdf/1609.02907.pdf. This is used in the GCN model for 
+        classification task on graph-structured data.
+        :param units: Number of hidden units for the layer.
+            type units: int.
+        :param use_bias: Boolean variable to determine whether to use bias.
+            type use_bias: bool.
+        :param sparse_input: Boolean variable to check if input tensor is sparse.
+            type sparse_input: bool.
+        :param kernel_initializer: Weight initializer for the GCN kernel.
+        :param bias_initializer: Weight initializer for the bias.
+        :param kernel_regularizer: Weight regularizer for the GCN kernel.
+        :param bias_regularizer: Weight regularizer for the bias.
+        :param kernel_constraint: Weight value constraint for the GCN kernel.
+        :param bias_constraint: Weight value constraint for the bias.
+        :param kwargs:
+        """
+        if 'input_shape' not in kwargs and 'input_dim' in kwargs:
+            kwargs['input_shape'] = (kwargs.pop('input_dim'),)
+        super(GCNLayer, self).__init__(**kwargs)
+        self.units = units
+        self.use_bias = use_bias
+        self.sparse_input = sparse_input
+        self.kernel_initializer = initializers.get(kernel_initializer)
+        self.bias_initializer = initializers.get(bias_initializer)
+        self.kernel_regularizer = regularizers.get(kernel_regularizer)
+        self.bias_regularizer = regularizers.get(bias_regularizer)
+        self.kernel_constraint = constraints.get(kernel_constraint)
+        self.bias_constraint = constraints.get(bias_constraint)
+    
+    def build(self, input_shape):
+        self.kernel = self.add_weight(shape=(input_shape[-1], self.units),
+                                      initializer=self.kernel_initializer,
+                                      name='kernel',
+                                      regularizer=self.kernel_regularizer,
+                                      constraint=self.kernel_constraint,
+                                      trainable=True)
+        if self.use_bias:
+            self.bias = self.add_weight(shape=(self.units,),
+                                        initializer=self.bias_initializer,
+                                        name='bias',
+                                        regularizer=self.bias_regularizer,
+                                        constraint=self.bias_constraint,
+                                        trainable=True)
+        self.built = True
+    
+    def call(self, inputs, adj, **kwargs):
+        assert isinstance(adj, tf.SparseTensor), "Adjacency matrix should be a SparseTensor"
+        if self.sparse_input:
+            assert isinstance(inputs, tf.SparseTensor), "Input matrix should be a SparseTensor"
+            support = tf.sparse.sparse_dense_matmul(inputs, self.kernel)
+        else:
+            support = tf.matmul(inputs, self.kernel)
+        output = tf.sparse.sparse_dense_matmul(adj, support)
+        if self.use_bias:   
+            output = output + self.bias
+        else:
+            output = output
+        return output
+
+    def get_config(self):
+        config = {'units': self.units,
+                  'use_bias': self.use_bias,
+                  'sparse_input': self.sparse_input,
+                  'kernel_initializer': initializers.serialize(
+                      self.kernel_initializer),
+                  'bias_initializer': initializers.serialize(
+                      self.bias_initializer),
+                  'kernel_regularizer': regularizers.serialize(
+                      self.kernel_regularizer),
+                  'bias_regularizer': regularizers.serialize(
+                      self.bias_regularizer),
+                  'kernel_constraint': constraints.serialize(
+                      self.kernel_constraint),
+                  'bias_constraint': constraints.serialize(self.bias_constraint)
+        }
+        base_config = super(GCNLayer, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/sqlflow_models/gcn.py
+++ b/sqlflow_models/gcn.py
@@ -32,8 +32,14 @@ class GCN(tf.keras.Model):
             type dropout: float.
         :param nlayer: Number of GCNLayer to be used in the model.
             type nlayer: int.
-        :param feature_columns: a list of tf.feature_column. (Not used in this model)
-            type feature_columns: list.
+        :param id_col: Name for the column in database to be used as the id of each node.
+            type id_col: string.
+        :param feature_col: Name for the column in database to be used as the features of each node.
+            type feature_col: string.
+        :param from_node_col: Name for the column in database to be used as the from_node id of each edge.
+            type from_node_col: string.
+        :param to_node_col: Name for the column in database to be used as the to_node id of each edge.
+            type to_node_col: string.
         """
         super(GCN, self).__init__()
 

--- a/tests/test_gcn.py
+++ b/tests/test_gcn.py
@@ -1,0 +1,89 @@
+import sqlflow_models
+from tests.base import BaseTestCases
+
+import tensorflow as tf
+import numpy as np
+import unittest
+import random
+
+
+def build_karate_club_graph():
+    # All 78 edges are stored in two numpy arrays. One for source endpoints
+    # while the other for destination endpoints. 
+    # Credit to: https://docs.dgl.ai/tutorials/basics/1_first.html
+    src = np.array([1, 2, 2, 3, 3, 3, 4, 5, 6, 6, 6, 7, 7, 7, 7, 8, 8, 9, 10, 10,
+        10, 11, 12, 12, 13, 13, 13, 13, 16, 16, 17, 17, 19, 19, 21, 21,
+        25, 25, 27, 27, 27, 28, 29, 29, 30, 30, 31, 31, 31, 31, 32, 32,
+        32, 32, 32, 32, 32, 32, 32, 32, 32, 33, 33, 33, 33, 33, 33, 33,
+        33, 33, 33, 33, 33, 33, 33, 33, 33, 33])
+    dst = np.array([0, 0, 1, 0, 1, 2, 0, 0, 0, 4, 5, 0, 1, 2, 3, 0, 2, 2, 0, 4,
+        5, 0, 0, 3, 0, 1, 2, 3, 5, 6, 0, 1, 0, 1, 0, 1, 23, 24, 2, 23,
+        24, 2, 23, 26, 1, 8, 0, 24, 25, 28, 2, 8, 14, 15, 18, 20, 22, 23,
+        29, 30, 31, 8, 9, 13, 14, 15, 18, 19, 20, 22, 23, 26, 27, 28, 29, 30,
+        31, 32])
+    u = np.concatenate([src, dst])
+    v = np.concatenate([dst, src])
+    u = np.expand_dims(u, axis=1)
+    v = np.expand_dims(v, axis=1)
+    return np.concatenate([u,v], 1)
+
+def acc(y, label):
+    '''Function to calculate the accuracy.'''
+    ll = tf.equal(tf.argmax(label, -1), tf.argmax(y, -1))
+    accuarcy = tf.reduce_mean(tf.cast(ll, dtype=tf.float32))
+    return accuarcy
+
+def evaluate(x, y, model):
+    '''Function to evaluate the performance of model.'''
+    metric = dict()
+    y_pred = model.predict(x, batch_size=x[0].shape[0])
+    metric['acc'] = np.round(acc(y, y_pred), 5)
+    return metric
+
+class TestGCN(BaseTestCases.BaseTest):
+    def setUp(self):
+        feature = [[0,1,2]+random.sample(range(3, 20), 8),
+                   [0,1,2]+random.sample(range(18, 40),8),
+                   [0,1,2]+random.sample(range(38, 60),8),
+                   [0,1,2]+random.sample(range(58, 80),8)]
+        label = ['Shotokan', 'Gōjū-ryū', 'Wadō-ryū', 'Shitō-ryū']
+        nodes = np.array(list(range(34)))
+        edges = build_karate_club_graph()
+        features, labels = list(), list()
+        for i in range(34):
+            idx = random.randint(0,3)
+            features.append(np.eye(81)[feature[idx]].sum(0))
+            labels.append(label[idx])
+        self.inputs = [dict() for i in range(len(edges)*2)]
+        self.labels = list()
+        for i in range(len(edges)):
+            self.inputs[i]['id'] = tf.convert_to_tensor(edges[i][0])
+            self.inputs[i]['features'] = tf.convert_to_tensor(features[edges[i][0]])
+            self.inputs[i]['from_node_id'] = tf.convert_to_tensor(edges[i][0])
+            self.inputs[i]['to_node_id'] = tf.convert_to_tensor(edges[i][1])
+            self.labels.append(tf.convert_to_tensor([labels[edges[i][0]]]))
+        for i in range(len(edges)):
+            self.inputs[i+len(edges)]['id'] = tf.convert_to_tensor(edges[i][1])
+            self.inputs[i+len(edges)]['features'] = tf.convert_to_tensor(features[edges[i][1]])
+            self.inputs[i+len(edges)]['from_node_id'] = tf.convert_to_tensor(edges[i][0])
+            self.inputs[i+len(edges)]['to_node_id'] = tf.convert_to_tensor(edges[i][1])
+            self.labels.append(tf.convert_to_tensor([labels[edges[i][1]]]))
+        self.model = sqlflow_models.GCN(nhid=16, nclass=4, epochs=20, train_ratio=0.2, eval_ratio=0.15)
+        self.model_class = sqlflow_models.GCN
+
+    def test_train_and_predict(self):
+        self.setUp()
+        self.model.compile(optimizer=optimizer(),
+                           loss='categorical_crossentropy')
+        self.model.sqlflow_train_loop(zip(self.inputs, self.labels))
+        metric = evaluate([self.model.features, self.model.adjacency], self.model.labels, self.model)
+        print(metric)
+        assert (metric['acc'] > 0)
+
+def optimizer():
+    return tf.keras.optimizers.Adam(lr=0.01)
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/tests/test_gcn.py
+++ b/tests/test_gcn.py
@@ -36,7 +36,7 @@ def acc(y, label):
 def evaluate(x, y, model):
     '''Function to evaluate the performance of model.'''
     metric = dict()
-    y_pred = model.predict(x, batch_size=x[0].shape[0])
+    y_pred = model.predict(x)
     metric['acc'] = np.round(acc(y, y_pred), 5)
     return metric
 

--- a/tests/test_gcn.py
+++ b/tests/test_gcn.py
@@ -77,7 +77,6 @@ class TestGCN(BaseTestCases.BaseTest):
                            loss='categorical_crossentropy')
         self.model.sqlflow_train_loop(zip(self.inputs, self.labels))
         metric = evaluate([self.model.features, self.model.adjacency], self.model.labels, self.model)
-        print(metric)
         assert (metric['acc'] > 0)
 
 def optimizer():


### PR DESCRIPTION
Hi this is the PR about adding GCN to sqlflow, which relates to [#2714](https://github.com/sql-machine-learning/sqlflow/issues/2714), [#78](https://github.com/sql-machine-learning/models/issues/78).

This sql command is used to train the model, which can produce a result of accuracy about 83% on validation dataset.
```sql
SELECT cora.node.id, features, label as class, cora.edge.from_node_id, cora.edge.to_node_id FROM cora.node
LEFT JOIN cora.edge ON (cora.node.id = cora.edge.from_node_id OR cora.node.id = cora.edge.to_node_id)
ORDER BY cora.node.id
TO TRAIN sqlflow_models.GCN
WITH model.nhid=16, model.nclass=7, 
     model.epochs=200, model.train_ratio=0.15, 
     model.eval_ratio=0.2, validation.metrics="CategoricalAccuracy"
COLUMN DENSE(features)
LABEL class
INTO sqlflow_models.gcn_model;
```

If there is any question, please let me know.