### PR TITLE
Don't need install pip in the runnable Dockerfile.

### DIFF
--- a/runnables/Dockerfile
+++ b/runnables/Dockerfile
@@ -1,8 +1,7 @@
 FROM sqlflow/sqlflow:step
 
 RUN apt-get clean && apt-get update && \
-    apt-get -qq install python3-pip libmysqld-dev libmysqlclient-dev && \
-    ln -s /usr/bin/pip3 /usr/bin/pip
+    apt-get -qq install libmysqld-dev libmysqlclient-dev
 
 ADD ./requirements.txt /
 RUN pip3 install --no-cache-dir -r /requirements.txt && rm -rf /requirements.txt


### PR DESCRIPTION
`pip` has been already installed in the base image - sqlflow/sqlflow:step.