### PR TITLE
Remove OneClassSVM model log

### DIFF
--- a/sqlflow_models/one_class_svm.py
+++ b/sqlflow_models/one_class_svm.py
@@ -32,11 +32,6 @@ except Exception:
     except Exception:
         ENABLE_EAGER_EXECUTION = False
 
-if ENABLE_EAGER_EXECUTION:
-    print('eager execution mode is enabled')
-else:
-    print('eager execution mode is disabled')
-
 
 def dataset_reader(dataset):
     if ENABLE_EAGER_EXECUTION:


### PR DESCRIPTION
The printed log causes error:

```
2020/10/29 15:35:45 ExtractSymbol failed: invalid character 'e' looking for beginning of value eager execution mode is enabled
```